### PR TITLE
Refactor post password as parameter

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -2,8 +2,8 @@
 Contributors: KaeruCT
 Donate link: https://liberapay.com/KaeruCT
 Tags: password, protected, url, post, page
-Requires at least: 4.2.2
-Tested up to: 5.8.1
+Requires at least: 5.4
+Tested up to: 6.8.1
 Stable tag: trunk
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html


### PR DESCRIPTION
- Use template_redirect so that the password can be checked before setting the cookie
- Check if the parameter is set before doing anything
- Use the same code as WordPress core to set the cookie
- Remove the password from the URL after setting the cookie
- Increased the minimum WP version to 5.4. 1.2% of sites are still running on 5.4 https://wordpress.org/about/stats/
- Removed the backend JavaScript as not needed.
- Tested on WordPress 6.8 and 5.9.

<img width="1315" alt="image" src="https://github.com/user-attachments/assets/706a092f-fd66-45b6-af76-fdfa57dffd7f" />
